### PR TITLE
ComHpcAltPkg: Fix SCT RouteConfigConformance test failure

### DIFF
--- a/adlink-platforms/Platform/Ampere/ComHpcAltPkg/Library/PcieBoardLib/PcieBoardScreen.c
+++ b/adlink-platforms/Platform/Ampere/ComHpcAltPkg/Library/PcieBoardLib/PcieBoardScreen.c
@@ -1,6 +1,7 @@
 /** @file
 
   Copyright (c) 2020 - 2021, Ampere Computing LLC. All rights reserved.<BR>
+  Copyright (c) 2022, ARM Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -275,6 +276,8 @@ RouteConfig (
   } else if (HiiIsConfigHdrMatch (Configuration, &gPcieFormSetGuid, gPcieVarstoreName)) {
     BufferSize = sizeof (PCIE_VARSTORE_DATA);
     VarStoreConfig = (UINT8 *)&PrivateData->VarStoreConfig;
+  } else {
+    return EFI_NOT_FOUND;
   }
   ASSERT (VarStoreConfig != NULL);
 


### PR DESCRIPTION
Per UEFI Spec, if the target for the specified routing data is not 
found, EFI_HII_CONFIG_ROUTING_PROTOCOL.RouteConfig() should return 
EFI_NOT_FOUND.

In the current implementation, it doesn’t have code to handle the case 
that target for the specified routing data was not found, so it returns 
unexpected status EFI_INVALID_PARAMETER rather than EFI_NOT_FOUND. 

Signed-off-by: Sunny Wang <sunny.wang@arm.com>